### PR TITLE
Add PDF folder scan

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -11,14 +11,22 @@ def extract_text_from_pdf(file_path: Path) -> str:
         return ""
 
 
-def scan_foreign_docs(folder_path: str):
+def scan_pdfs(folder_path: str):
+    """Scan ``folder_path`` recursively and return info for all PDF files."""
+
     result = []
     for path in Path(folder_path).rglob("*.pdf"):
         text = extract_text_from_pdf(path)
+
         try:
             lang = detect(text)
         except Exception:
-            lang = 'unknown'
-        if lang not in ('ko', 'unknown'):
-            result.append({'name': path.name, 'path': str(path), 'lang': lang})
+            lang = "unknown"
+
+        result.append({"name": path.name, "path": str(path), "lang": lang})
+
     return result
+
+
+# Backwards compatibility
+scan_foreign_docs = scan_pdfs

--- a/server.py
+++ b/server.py
@@ -18,7 +18,7 @@ def index():
 @app.route('/api/select-folder', methods=['POST'])
 def select_folder():
     folder_path = request.json.get('path')
-    files = file_utils.scan_foreign_docs(folder_path)
+    files = file_utils.scan_pdfs(folder_path)
     return jsonify({'files': files})
 
 


### PR DESCRIPTION
## Summary
- show all PDF files when scanning a folder instead of filtering by language

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'webview')*
