### PR TITLE
Add file selection and listing

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,15 @@ def open_file_dialog():
     from tkinter import filedialog
     root = tk.Tk()
     root.withdraw()
-    file_path = filedialog.askopenfilename()
+    file_path = filedialog.askopenfilename(
+        filetypes=[
+            ("All supported", "*.pdf *.doc *.docx *.txt *.html"),
+            ("PDF files", "*.pdf"),
+            ("Word files", "*.doc *.docx"),
+            ("Text files", "*.txt"),
+            ("HTML files", "*.html"),
+        ]
+    )
     root.destroy()
     return file_path
 

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -11,6 +11,25 @@ function toggleSidebar() {
   }
 }
 
+function addFileToList(filePath) {
+  const fileList = document.getElementById('file-list');
+  const li = document.createElement('li');
+  const name = filePath.split(/[/\\]/).pop();
+  li.textContent = name;
+  if (name.toLowerCase().endsWith('.pdf')) {
+    li.onclick = () => loadPDFView(filePath);
+  }
+  fileList.appendChild(li);
+}
+
+function triggerFileSelect() {
+  window.pywebview.api.open_file_dialog().then(filePath => {
+    if (filePath) {
+      addFileToList(filePath);
+    }
+  });
+}
+
 async function selectFolder(folderPath) {
   const response = await fetch('/api/select-folder', {
     method: 'POST',

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <div id="container">
   <button id="sidebar-toggle" onclick="toggleSidebar()">≡</button>
   <div id="sidebar">
-    <button onclick="window.pywebview.api.open_file_dialog()">파일선택</button>
+    <button onclick="triggerFileSelect()">파일선택</button>
     <button onclick="triggerFolderSelect()">폴더선택</button>
     <ul id="file-list"></ul>
   </div>


### PR DESCRIPTION
## Summary
- restrict supported file types in `open_file_dialog`
- show selected file names in sidebar list
- add JS helpers for file selection

## Testing
- `python -m py_compile app.py server.py file_utils.py translator.py tasks.py progress_manager.py`