### PR TITLE
Implement document preview with page navigation

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,7 +2,9 @@ from flask import Flask, jsonify, request, send_from_directory, render_template
 import threading
 import base64
 from io import BytesIO
-from pdf2image import convert_from_path
+from pathlib import Path
+from pdf2image import convert_from_path, pdfinfo_from_path
+from langdetect import detect
 
 import file_utils
 import tasks
@@ -22,14 +24,28 @@ def select_folder():
     return jsonify({'files': files})
 
 
+@app.route('/api/select-file', methods=['POST'])
+def select_file():
+    path = request.json.get('path')
+    file_path = Path(path)
+    text = file_utils.extract_text_from_pdf(file_path)
+    try:
+        lang = detect(text)
+    except Exception:
+        lang = 'unknown'
+    return jsonify({'name': file_path.name, 'path': path, 'lang': lang})
+
+
 @app.route('/api/view-pdf', methods=['POST'])
 def view_pdf():
     path = request.json['path']
-    images = convert_from_path(path, first_page=1, last_page=1)
+    page = int(request.json.get('page', 1))
+    info = pdfinfo_from_path(path)
+    images = convert_from_path(path, first_page=page, last_page=page)
     buffered = BytesIO()
     images[0].save(buffered, format='PNG')
     img_str = base64.b64encode(buffered.getvalue()).decode()
-    return jsonify({'image': img_str})
+    return jsonify({'image': img_str, 'total_pages': info.get('Pages', 1)})
 
 
 @app.route('/api/translate', methods=['POST'])

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,3 +53,33 @@
   overflow-y: auto;
   border-left: 1px solid #eee;
 }
+
+/* file list */
+#file-list li {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+#file-list li:hover {
+  background: #eaeaea;
+}
+
+#file-list .file-name {
+  margin-left: 5px;
+  flex: 1;
+}
+
+#page-controls {
+  text-align: center;
+  margin-top: 10px;
+}
+
+#page-controls button {
+  margin: 0 5px;
+}
+
+.hidden {
+  display: none;
+}

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -11,43 +11,92 @@ function toggleSidebar() {
   }
 }
 
-async function selectFolder(folderPath) {
-  const response = await fetch('/api/select-folder', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: folderPath })
-  });
-  const data = await response.json();
-  const fileList = document.getElementById('file-list');
-  fileList.innerHTML = '';
-  data.files.forEach(file => {
+  async function selectFolder(folderPath) {
+    const response = await fetch('/api/select-folder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: folderPath })
+    });
+    const data = await response.json();
+    const fileList = document.getElementById('file-list');
+    fileList.innerHTML = '';
+    data.files.forEach(file => addFileItem(file));
+  }
+
+  async function selectFile(filePath) {
+    const response = await fetch('/api/select-file', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: filePath })
+    });
+    const file = await response.json();
+    addFileItem(file);
+  }
+
+  function addFileItem(file) {
+    const fileList = document.getElementById('file-list');
     const li = document.createElement('li');
-    li.textContent = file.name + ' (' + file.lang + ')';
-    li.onclick = () => loadPDFView(file.path);
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    const span = document.createElement('span');
+    span.className = 'file-name';
+    span.textContent = file.name + ' (' + file.lang + ')';
+    span.onclick = () => loadPDFView(file.path, 1);
+    li.appendChild(checkbox);
+    li.appendChild(span);
     fileList.appendChild(li);
-  });
-}
+  }
 
-function triggerFolderSelect() {
-  window.pywebview.api.open_folder_dialog().then(folderPath => {
-    if (folderPath) {
-      selectFolder(folderPath);
+  function triggerFolderSelect() {
+    window.pywebview.api.open_folder_dialog().then(folderPath => {
+      if (folderPath) {
+        selectFolder(folderPath);
+      }
+    });
+  }
+
+  function triggerFileSelect() {
+    window.pywebview.api.open_file_dialog().then(filePath => {
+      if (filePath) {
+        selectFile(filePath);
+      }
+    });
+  }
+
+  let currentFile = null;
+  let currentPage = 1;
+  let totalPages = 1;
+
+  function loadPDFView(filePath, page) {
+    fetch('/api/view-pdf', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: filePath, page: page })
+    })
+    .then(res => res.json())
+    .then(data => {
+      const viewer = document.getElementById('viewer-container');
+      viewer.innerHTML = '<img src="data:image/png;base64,' + data.image + '">';
+      currentFile = filePath;
+      currentPage = page;
+      totalPages = data.total_pages;
+      document.getElementById('page-info').textContent = page + ' / ' + totalPages;
+      const controls = document.getElementById('page-controls');
+      controls.classList.toggle('hidden', totalPages <= 1);
+    });
+  }
+
+  document.getElementById('prev-page').onclick = () => {
+    if (currentPage > 1) {
+      loadPDFView(currentFile, currentPage - 1);
     }
-  });
-}
+  };
 
-function loadPDFView(filePath) {
-  fetch('/api/view-pdf', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: filePath })
-  })
-  .then(res => res.json())
-  .then(data => {
-    const left = document.getElementById('left-panel');
-    left.innerHTML = '<img src="data:image/png;base64,' + data.image + '">';
-  });
-}
+  document.getElementById('next-page').onclick = () => {
+    if (currentPage < totalPages) {
+      loadPDFView(currentFile, currentPage + 1);
+    }
+  };
 
 function startTranslation(filePath) {
   fetch('/api/translate', {

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,12 +9,19 @@
 <div id="container">
   <button id="sidebar-toggle" onclick="toggleSidebar()">≡</button>
   <div id="sidebar">
-    <button onclick="window.pywebview.api.open_file_dialog()">파일선택</button>
+    <button onclick="triggerFileSelect()">파일선택</button>
     <button onclick="triggerFolderSelect()">폴더선택</button>
     <ul id="file-list"></ul>
   </div>
   <div id="main-panel">
-    <div id="left-panel">왼쪽 패널</div>
+    <div id="left-panel">
+      <div id="viewer-container"></div>
+      <div id="page-controls" class="hidden">
+        <button id="prev-page">◀</button>
+        <span id="page-info"></span>
+        <button id="next-page">▶</button>
+      </div>
+    </div>
     <div id="right-panel">오른쪽 패널</div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add buttons to pick files or folders
- show selectable document list with checkboxes
- display chosen file in viewer and navigate pages
- support page requests in PDF viewer API

## Testing
- `python -m py_compile $(git ls-files '*.py')`