### PR TITLE
Add translation button in sidebar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,3 +53,12 @@
   overflow-y: auto;
   border-left: 1px solid #eee;
 }
+
+#translation-panel {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 10px;
+  border-top: 1px solid #ccc;
+  background: #f5f5f5;
+}

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -22,8 +22,15 @@ async function selectFolder(folderPath) {
   fileList.innerHTML = '';
   data.files.forEach(file => {
     const li = document.createElement('li');
-    li.textContent = file.name + ' (' + file.lang + ')';
-    li.onclick = () => loadPDFView(file.path);
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = file.path;
+    checkbox.classList.add('file-checkbox');
+    const span = document.createElement('span');
+    span.textContent = file.name + ' (' + file.lang + ')';
+    span.onclick = () => loadPDFView(file.path);
+    li.appendChild(checkbox);
+    li.appendChild(span);
     fileList.appendChild(li);
   });
 }
@@ -56,3 +63,15 @@ function startTranslation(filePath) {
     body: JSON.stringify({ path: filePath })
   });
 }
+
+function translateSelected() {
+  const checked = document.querySelectorAll('.file-checkbox:checked');
+  checked.forEach(cb => {
+    startTranslation(cb.value);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('translate-btn');
+  if (btn) btn.addEventListener('click', translateSelected);
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,9 @@
     <button onclick="window.pywebview.api.open_file_dialog()">파일선택</button>
     <button onclick="triggerFolderSelect()">폴더선택</button>
     <ul id="file-list"></ul>
+    <div id="translation-panel">
+      <button id="translate-btn">번역하기</button>
+    </div>
   </div>
   <div id="main-panel">
     <div id="left-panel">왼쪽 패널</div>


### PR DESCRIPTION
## Summary
- add translation panel with button in sidebar
- allow selecting multiple files via checkboxes
- send translation requests for checked files when button is clicked

## Testing
- `pytest -q` *(fails: command not found)*