### PR TITLE
Refactor language constants

### DIFF
--- a/server.py
+++ b/server.py
@@ -27,6 +27,31 @@ from tasks import get_translated_file_path # Import the new helper function
 
 app = Flask(__name__, static_folder='static', template_folder='templates')
 
+# 공통 언어 코드 -> 언어 이름 매핑
+LANGUAGE_NAMES: Dict[str, str] = {
+    'ko': 'Korean',
+    'en': 'English',
+    'ja': 'Japanese',
+    'zh-cn': 'Chinese (Simplified)',
+    'zh-tw': 'Chinese (Traditional)',
+    'es': 'Spanish',
+    'fr': 'French',
+    'de': 'German',
+    'ru': 'Russian',
+    'ar': 'Arabic',
+    'pt': 'Portuguese',
+    'it': 'Italian',
+    'vi': 'Vietnamese',
+    'th': 'Thai',
+    'id': 'Indonesian',
+    'hi': 'Hindi',
+}
+
+
+def get_language_name(code: str) -> str:
+    """언어 코드를 사람이 읽을 수 있는 언어명으로 변환합니다."""
+    return LANGUAGE_NAMES.get(code, f'Unknown ({code})')
+
 # 서비스 초기화 플래그
 _services_initialized = False
 
@@ -156,7 +181,7 @@ def scan_directory_for_foreign_docs(directory: Path) -> List[Dict[str, Any]]:
                     'path': str(file_path),
                     'size': file_size,
                     'language': lang,  # 언어 코드 (예: 'ko', 'en', 'ja')
-                    'language_name': lang.upper() if lang else 'Unknown',  # 언어 코드 대문자
+                    'language_name': get_language_name(lang),
                     'confidence': round(confidence * 100, 1) if confidence else 0,  # 백분율로 변환
                     'is_foreign': lang != 'ko' and confidence and confidence >= 0.5  # 한국어가 아닌지 여부
                 }
@@ -482,26 +507,7 @@ def check_language():
         lang, confidence = file_utils.detect_document_language(Path(file_path))
         
         # 언어 코드를 언어명으로 변환
-        language_names = {
-            'ko': 'Korean',
-            'en': 'English',
-            'ja': 'Japanese',
-            'zh-cn': 'Chinese (Simplified)',
-            'zh-tw': 'Chinese (Traditional)',
-            'es': 'Spanish',
-            'fr': 'French',
-            'de': 'German',
-            'ru': 'Russian',
-            'ar': 'Arabic',
-            'pt': 'Portuguese',
-            'it': 'Italian',
-            'vi': 'Vietnamese',
-            'th': 'Thai',
-            'id': 'Indonesian',
-            'hi': 'Hindi'
-        }
-        
-        language_name = language_names.get(lang, f'Unknown ({lang})')
+        language_name = get_language_name(lang)
         
         return jsonify({
             'success': True,
@@ -612,28 +618,10 @@ def select_file():
                 # file_utils의 언어 감지 함수 사용
                 lang, confidence = file_utils.detect_document_language(Path(file_path))
                 
-                # 언어 코드를 언어명으로 변환
-                language_names = {
-                    'ko': 'Korean',
-                    'en': 'English',
-                    'ja': 'Japanese',
-                    'zh-cn': 'Chinese (Simplified)',
-                    'zh-tw': 'Chinese (Traditional)',
-                    'es': 'Spanish',
-                    'fr': 'French',
-                    'de': 'German',
-                    'ru': 'Russian',
-                    'pt': 'Portuguese',
-                    'it': 'Italian',
-                    'vi': 'Vietnamese',
-                    'th': 'Thai',
-                    'id': 'Indonesian',
-                    'hi': 'Hindi'
-                }
-                
+                # 언어 코드와 이름 저장
                 file_info.update({
                     'language': lang,
-                    'language_name': language_names.get(lang, f'Unknown ({lang})'),
+                    'language_name': get_language_name(lang),
                     'confidence': round(confidence * 100, 1)  # 백분율로 변환
                 })
                 
@@ -643,7 +631,7 @@ def select_file():
                     ext = file_path.suffix
                     
                     # 기존에 언어 코드가 이미 붙어있는지 확인하고 제거
-                    for code in language_names.keys():
+                    for code in LANGUAGE_NAMES.keys():
                         if name_without_ext.lower().endswith(f'_{code.lower()}'):
                             name_without_ext = name_without_ext[:-len(f'_{code.upper()}')]
                             break


### PR DESCRIPTION
## Summary
- centralize language mapping in `server.py`
- use `get_language_name` helper when reporting language

## Testing
- `python -m py_compile server.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683d5eeee31c832a9a5493b3c2a13056