### PR TITLE
Fix local markdown rendering

### DIFF
--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -12,11 +12,14 @@ function renderMarkdown(mdText) {
     if (typeof marked !== 'undefined' && typeof marked.parse === 'function') {
       return marked.parse(mdText);
     }
+    if (typeof simpleMarkdownParse === 'function') {
+      return simpleMarkdownParse(mdText);
+    }
   } catch (e) {
-    console.warn('marked.parse 실패:', e);
+    console.error('마크다운 파싱 실패:', e);
   }
-  // marked가 로드되지 않았거나 오류 발생 시 원본 텍스트 표시
-  return `<pre class="whitespace-pre-wrap text-sm">${mdText}</pre>`;
+  // 파싱에 완전히 실패한 경우 간단한 오류 메시지만 표시
+  return '<p class="text-red-500">마크다운 렌더링 오류가 발생했습니다.</p>';
 }
 
 // 언어 코드를 국기 이모지로 변환하는 함수

--- a/static/js/simple_markdown.js
+++ b/static/js/simple_markdown.js
@@ -1,0 +1,40 @@
+function simpleMarkdownParse(mdText) {
+  if (!mdText) return '';
+  // Escape HTML special characters
+  const escapeHtml = (str) => str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  let html = escapeHtml(mdText);
+
+  // Headings ###, ##, #
+  html = html.replace(/^###\s+(.*)$/gm, '<h3>$1</h3>');
+  html = html.replace(/^##\s+(.*)$/gm, '<h2>$1</h2>');
+  html = html.replace(/^#\s+(.*)$/gm, '<h1>$1</h1>');
+
+  // Bold **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+  // Italic *text* or _text_
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  html = html.replace(/_(.+?)_/g, '<em>$1</em>');
+
+  // Inline code `code`
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Unordered lists
+  html = html.replace(/^(?:-|\*)\s+(.*)$/gm, '<li>$1</li>');
+  html = html.replace(/(<li>.*<\/li>\n?)+/g, function(match) {
+    return '<ul>' + match.trim() + '</ul>\n';
+  });
+
+  // Paragraphs
+  html = html.replace(/^(?!<h\d|<ul|<li|<\/li|<\/ul)(.+)$/gm, '<p>$1</p>');
+
+  // Line breaks: two spaces at end of line or two newlines
+  html = html.replace(/\n{2,}/g, '<br/>\n');
+
+  return html;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <!-- 로컬에서 간단한 마크다운 파서를 사용합니다 -->
+  <script src="/static/js/simple_markdown.js"></script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
     


### PR DESCRIPTION
## Summary
- render markdown using a simple local parser when `marked` is unavailable
- stop falling back to `<pre>` text output
- load the local markdown parser instead of CDN

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68400831c960832aa90e8c0713de6fc9