### PR TITLE
Add paragraph-based translation using Argos Translate

### DIFF
--- a/argos_translator.py
+++ b/argos_translator.py
@@ -1,0 +1,132 @@
+"""Argos Translate 기반 Markdown 문서 번역기"""
+
+from dataclasses import dataclass
+from typing import List, Dict, Optional
+import re
+
+try:
+    import argostranslate.translate
+    ARGOS_AVAILABLE = True
+except ImportError:
+    ARGOS_AVAILABLE = False
+
+try:
+    from langdetect import detect, DetectorFactory
+    DetectorFactory.seed = 0
+    LANGDETECT_AVAILABLE = True
+except ImportError:
+    LANGDETECT_AVAILABLE = False
+
+
+@dataclass
+class TranslationUnit:
+    content: str
+    unit_type: str  # paragraph, sentence, header, code, empty
+    is_translatable: bool
+    metadata: Dict
+
+
+class MarkdownTranslator:
+    def __init__(self, source_lang: str = "auto", target_lang: str = "ko"):
+        self.source_lang = source_lang
+        self.target_lang = target_lang
+        self.detected_language: Optional[str] = None
+
+    def detect_language(self, text: str) -> str:
+        if not LANGDETECT_AVAILABLE:
+            return "en"
+        sample = text[:1000]
+        try:
+            return detect(sample)
+        except Exception:
+            return "en"
+
+    def split_into_units(self, markdown_text: str, split_by_sentence: bool = False) -> List[TranslationUnit]:
+        units: List[TranslationUnit] = []
+        lines = markdown_text.split("\n")
+        paragraph: List[str] = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                if paragraph:
+                    units.extend(self._process_paragraph(paragraph, split_by_sentence))
+                    paragraph = []
+                code_block = [line]
+                i += 1
+                while i < len(lines) and not lines[i].strip().startswith("```"):
+                    code_block.append(lines[i])
+                    i += 1
+                if i < len(lines):
+                    code_block.append(lines[i])
+                units.append(TranslationUnit("\n".join(code_block), "code", False, {"line_count": len(code_block)}))
+            elif stripped.startswith("#"):
+                if paragraph:
+                    units.extend(self._process_paragraph(paragraph, split_by_sentence))
+                    paragraph = []
+                level = len(stripped) - len(stripped.lstrip('#'))
+                header_text = stripped[level:].strip()
+                units.append(TranslationUnit(line, "header", bool(header_text), {"level": level, "text": header_text}))
+            elif not stripped:
+                if paragraph:
+                    units.extend(self._process_paragraph(paragraph, split_by_sentence))
+                    paragraph = []
+                units.append(TranslationUnit("", "empty", False, {}))
+            else:
+                paragraph.append(line)
+            i += 1
+        if paragraph:
+            units.extend(self._process_paragraph(paragraph, split_by_sentence))
+        return units
+
+    def _process_paragraph(self, lines: List[str], split_by_sentence: bool) -> List[TranslationUnit]:
+        text = "\n".join(lines)
+        if not text.strip():
+            return []
+        if split_by_sentence:
+            sentences = self._split_sentences(text)
+            return [TranslationUnit(s, "sentence", True, {}) for s in sentences if s.strip()]
+        else:
+            return [TranslationUnit(text, "paragraph", True, {"line_count": len(lines)})]
+
+    def _split_sentences(self, text: str) -> List[str]:
+        pattern = r"(?<=[.!?])\s+(?=[A-Z])"
+        sentences = re.split(pattern, text)
+        return [s.strip() for s in sentences if s.strip()]
+
+    def translate_unit(self, unit: TranslationUnit) -> str:
+        if not unit.is_translatable or not ARGOS_AVAILABLE:
+            return unit.content
+        src = self.detected_language if self.source_lang == "auto" and self.detected_language else self.source_lang
+        try:
+            return argostranslate.translate.translate(unit.content, src, self.target_lang)
+        except Exception:
+            return unit.content
+
+    def translate_document(self, markdown_text: str, split_by_sentence: bool = False) -> List[str]:
+        if self.source_lang == "auto":
+            self.detected_language = self.detect_language(markdown_text)
+        units = self.split_into_units(markdown_text, split_by_sentence)
+        translated: List[str] = []
+        for unit in units:
+            translated.append(self.translate_unit(unit))
+        return translated
+
+
+def translate_markdown(markdown_text: str, path: Optional[str] = None, source_lang: str = "auto", target_lang: str = "ko", split_by_sentence: bool = False) -> str:
+    translator = MarkdownTranslator(source_lang, target_lang)
+    translations = translator.translate_document(markdown_text, split_by_sentence)
+
+    if path:
+        from progress_manager import progress_manager
+        chunks_info = [
+            {"index": i, "header": "paragraph", "size": len(unit), "status": "completed"}
+            for i, unit in enumerate(translations)
+        ]
+        progress_manager.set_total_chunks(path, len(translations), chunks_info)
+        for i, text in enumerate(translations):
+            progress_manager.add_chunk_result(path, i, text)
+        progress_manager.finish(path)
+
+    return "\n".join(translations)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ PyYAML>=6.0.0  # 설정 파일 처리
 transformers>=4.0.0
 torch>=1.8.0  # Specify a version or range as needed
 tqdm>=4.60.0 # For progress bars
+argostranslate>=1.8.0
 
 # 의존성 주의:
 # 1. pdf2image 사용을 위해 poppler 설치 필요 (Windows: https://github.com/oschwartz10612/poppler-windows/releases/)

--- a/tasks.py
+++ b/tasks.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 import logging
 
-from file_utils import convert_pdf_to_markdown # Assuming this returns Path to converted .md
-from translator import translate_markdown # Assuming this takes MD string, returns translated MD string
+from file_utils import convert_pdf_to_markdown  # PDF를 Markdown 문자열로 변환
+from argos_translator import translate_markdown  # Markdown 문자열을 번역
 from progress_manager import progress_manager
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- replace NLLB translator usage with new Argos Translate based module
- chunk Markdown documents by paragraphs and translate using Argos
- update task runner to call the new translator
- add `argostranslate` to dependencies

## Testing
- `python -m py_compile argos_translator.py tasks.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684f82c11d0c832a903f9e5f15943223